### PR TITLE
match ChromeDriver version to installed Chrome package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,12 @@ RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add
 RUN echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
 
 RUN apt-get update && \
-  apt-get install -y google-chrome-unstable
+  apt-get install -y google-chrome-beta
 
 RUN pip3 install selenium
 
-RUN wget -q https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_linux64.zip && \
-  unzip chromedriver_linux64.zip && \
-  mv chromedriver /usr/bin && \
-  chmod +x /usr/bin/chromedriver && \
-  rm chromedriver_linux64.zip
+COPY install_chromedriver.sh run.py run_endpoint.sh /
 
-COPY run.py run_endpoint.sh /
+RUN /install_chromedriver.sh
 
 ENTRYPOINT [ "/run_endpoint.sh" ]

--- a/install_chromedriver.sh
+++ b/install_chromedriver.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+CHROME_VERSION="$(dpkg-query -W -f='${source:Upstream-Version}' google-chrome-beta)"
+
+echo "Installing ChromeDriver $CHROME_VERSION"
+
+wget -q "https://chromedriver.storage.googleapis.com/$CHROME_VERSION/chromedriver_linux64.zip"
+
+unzip chromedriver_linux64.zip
+
+mv chromedriver /usr/bin
+chmod +x /usr/bin/chromedriver
+
+rm chromedriver_linux64.zip

--- a/run.py
+++ b/run.py
@@ -29,7 +29,7 @@ f.close()
 options = webdriver.ChromeOptions()
 options.gpu = False
 options.headless = True
-options.binary_location = "/usr/bin/google-chrome-unstable"
+options.binary_location = "/usr/bin/google-chrome-beta"
 options.add_argument("--no-sandbox")
 options.add_argument("--enable-quic")
 options.add_argument("--quic-version=h3-29")


### PR DESCRIPTION
I originally tried to hack the Dockerfile to use some kind of variable
in the wget command, but it doesn't seem to be possible, so instead I
refactored the Chrome driver installation into its own shell script.

This also requires installing Chrome beta instead of unstable, as there
is currently only a ChromeDriver version for beta.