### PR TITLE
Update to QUIC v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 
 RUN pip3 install selenium
 
-ENV CHROMEDRIVER_VERSION="89.0.4389.23"
+ENV CHROMEDRIVER_VERSION="98.0.4758.80"
 RUN wget -q "https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" && \
   unzip chromedriver_linux64.zip && \
   mv chromedriver /usr/bin && \

--- a/run.py
+++ b/run.py
@@ -38,7 +38,7 @@ options.headless = True
 options.binary_location = "/usr/bin/google-chrome-beta"
 options.add_argument("--no-sandbox")
 options.add_argument("--enable-quic")
-options.add_argument("--quic-version=h3-29")
+options.add_argument("--quic-version=80")
 options.add_argument("--origin-to-force-quic-on=" + server)
 options.add_argument("--log-net-log=/logs/chrome.json")
 options.add_argument("--net-log-capture-mode=IncludeSensitive")


### PR DESCRIPTION
This change should update the QUIC version used to the final RFC version 1. I believe version `80` is the correct value, based on the definition in the Chromium source: [quic_versions.h](https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quic/core/quic_versions.h;drc=369fb686729e7eb20d2bd09717cec14269a399d7;l=126)