### PR TITLE
Update ChromeDriver to v109.0.5414.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 
 RUN pip3 install selenium
 
-ENV CHROMEDRIVER_VERSION="107.0.5304.18"
+ENV CHROMEDRIVER_VERSION="109.0.5414.25"
 RUN wget -q "https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" && \
   unzip chromedriver_linux64.zip && \
   mv chromedriver /usr/bin && \


### PR DESCRIPTION
Update ChromeDriver to v109.0.5414.25 to fix interop failures.

```
client          | selenium.common.exceptions.SessionNotCreatedException: Message: session not created: This version of ChromeDriver only supports Chrome version 107
client          | Current browser version is 109.0.5414.46 with binary path /usr/bin/google-chrome-beta
```