### PR TITLE
Check that files in the download directory aren't temporary files

### DIFF
--- a/run.py
+++ b/run.py
@@ -72,7 +72,7 @@ def check_files() -> bool:
     files = os.listdir(DOWNLOADS)
     if len(files) < len(requests):
         return False
-    return len([f for f in files if ".crdownload" in f]) == 0
+    return len([f for f in files if ".crdownload" in f or ".com.google.Chrome." in f]) == 0
 
 
 while not check_files():


### PR DESCRIPTION
OpenSSL has recently been encountering occasional issue between its own interop runner and this Chrome QUIC interop runner for the HTTP3 test. After some investigation, I noticed that Google Chrome will create files that start with `.com.google.Chrome.` before creating the `<filename>.crdownload` files (e.g. `.com.google.Chrome.3n2d8V`). These files are incorrectly determined to be a completely downloaded file, and the Chrome instance is closed prematurely. This PR updates `run.py` to ignore these temporary files in addition to the `<filename>.crdownload` files.

Another approach could be to specifically check for each downloaded file, as the urls are passed it to the application from the container. This has the added benefit of being resistant to future changes in how Chrome downloads files.

Fixes: https://github.com/openssl/project/issues/1145