### PR TITLE
update ChromeDriver to 143.0.7499.40

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 
 RUN pip3 install selenium --break-system-packages
 
-ENV CHROMEDRIVER_VERSION="135.0.7049.41"
+ENV CHROMEDRIVER_VERSION="143.0.7499.40"
 RUN wget -q "https://storage.googleapis.com/chrome-for-testing-public/$CHROMEDRIVER_VERSION/linux64/chromedriver-linux64.zip" && \
   unzip chromedriver-linux64.zip && \
   mv chromedriver-linux64/chromedriver /usr/bin && \


### PR DESCRIPTION
Recent update to chrome in the ubuntu 22.04 base container created a mismatch between it and the corresponding chromedriver, which led to run time breakage:
https://github.com/openssl/openssl/actions/runs/19998189404/job/57373873534

Fix it by updating the chromedriver to the matching latest stable version

Fixes #455